### PR TITLE
21 remove simplified concept from network overline

### DIFF
--- a/R/network_overline.R
+++ b/R/network_overline.R
@@ -1,29 +1,34 @@
-#' Aggregate lines based on overlap with simplified network
+#' Aggregate lines based on overlap with target network
 #'
-#' @param network sf. A spatial object representing the simplified network.
-#' @param df sf. A spatial object representing the lines to aggregate.
+#' @param target_network sf. A spatial object representing the target network.
+#' @param lines sf. A spatial object representing the lines to aggregate.
 #' @param attr String. The attribute to aggregate the lines by.
-#' @param network_segment_length Integer (Default 100). If not NA, network is split in segments of defined meters.
+#' @param target_network_split Integer (Default 100). If not NA, network is split in segments of defined meters.
 #' @param fun Method (Default \code{base::sum}). Function to summarise the attributes by.
 #' @param join_dist Integer (Default 10). Meters to consider when joining routes and network segments.
 #'
 #' @details
-#' This method allows for the lines aggregation. Given a simplified network, it identifies (using \code{stplanr::rnet_join()})
+#' This method allows for the lines aggregation. Given a target network, it identifies (using \code{stplanr::rnet_join()})
 #' the segments corresponding to each line and uses them to aggregate the attribute defined in the parameters.
 #'
+#' It provides an alternative to \code{GTFShift::get_route_frequency_hourly()} with the attribute \code{overline=TRUE}, which
+#' creates an aggregated network based on the lines overlap. Instead, \code{GTFShift::network_overline()} finds, for each network
+#' segment, the overlapping lines and aggregates their \code{attr} values, using \code{fun}.
 #'
-#' @returns A spatial object of the network provided, extended with the aggregated values.
-#' A \code{segment} column will be also added to the network, as a unique identifier used for the aggregation process.
+#'
+#' @returns A spatial object of the target network, extended with the aggregated values.
 #'
 #' @examples
-# \dontrun{
-#   network = st_read("network_centerlines.gpkg")
-#   frequency_analysis = GTFShift::get_route_frequency_hourly(gtfs)
-#   GTFShift::network_overline(network,
-#                              f
-#                              requency_analysis |> filter(arrival_hour == 8),
-#                              attr = "frequency")
-# }
+#' \dontrun{
+#' gtfs <- GTFShift::load_feed("https://operator.com/gtfs.zip")
+#' target_network = st_read("network_centerlines.gpkg")
+#' frequency_analysis <- GTFShift::get_route_frequency_hourly(gtfs, overline=FALSE)
+#' GTFShift::network_overline(
+#'   target_network,
+#'   frequency_analysis %>% filter(arrival_hour==8),
+#'   attr = "frequency"
+#' )
+#' }
 #'
 #' @seealso [stplanr::rnet_join]
 #'
@@ -32,28 +37,29 @@
 #' @import dplyr
 #'
 #' @export
-
-network_overline = function(network,
-                            df,
-                            attr,
-                            network_segment_length = 100,
-                            fun = sum,
-                            join_dist = 10) {
+network_overline <- function(
+    target_network,
+    lines,
+    attr,
+    target_network_split=100,
+    fun=sum,
+    join_dist=10
+) {
   # 1. Prepare network
-  network_line = stplanr::line_cast(st_transform(network, crs = 3857))
-
-  if (!is.na(network_segment_length)) {
-    network_segmented = stplanr::line_segment(l = network_line,
-                                              segment_length = network_segment_length) |>
-      mutate(segment = row_number())
+  network_line = stplanr::line_cast(st_transform(target_network, crs=3857))
+  if (!is.na(target_network_split)) {
+    network_segmented = stplanr::line_segment(
+      network_line,
+      segment_length=target_network_split
+    ) %>% mutate(segment=row_number())
   } else {
     network_segmented = network_line |>
       mutate(segment = row_number())
   }
 
-  df = df |>
-    st_transform(crs = 3857) |>
-    mutate(df_id = row_number())
+  df = lines %>%
+    st_transform(crs=3857) %>%
+    mutate(df_id=row_number())
 
   # 2. Overlap df and network segments
   df_network_match = rnet_join(
@@ -78,9 +84,10 @@ network_overline = function(network,
     summarise(!!attr := fun(frequency))
 
   # 4. Get geometry back
-  result = network_segmented |>
-    filter(segment %in% df_network_segment$segment) |>
-    left_join(df_network_segment, by = "segment")
+  result = network_segmented %>%
+    filter(segment %in% df_network_segment$segment) %>%
+    left_join(df_network_segment, by="segment") %>%
+    select(-segment)
 
   return(result)
 }

--- a/R/network_overline.R
+++ b/R/network_overline.R
@@ -25,7 +25,7 @@
 #' frequency_analysis <- GTFShift::get_route_frequency_hourly(gtfs, overline=FALSE)
 #' GTFShift::network_overline(
 #'   target_network,
-#'   frequency_analysis %>% filter(arrival_hour==8),
+#'   frequency_analysis |> filter(arrival_hour==8),
 #'   attr = "frequency"
 #' )
 #' }
@@ -51,14 +51,14 @@ network_overline <- function(
     network_segmented = stplanr::line_segment(
       network_line,
       segment_length=target_network_split
-    ) %>% mutate(segment=row_number())
+    ) |> mutate(segment=row_number())
   } else {
     network_segmented = network_line |>
       mutate(segment = row_number())
   }
 
-  df = lines %>%
-    st_transform(crs=3857) %>%
+  df = lines |>
+    st_transform(crs=3857) |>
     mutate(df_id=row_number())
 
   # 2. Overlap df and network segments
@@ -84,9 +84,9 @@ network_overline <- function(
     summarise(!!attr := fun(frequency))
 
   # 4. Get geometry back
-  result = network_segmented %>%
-    filter(segment %in% df_network_segment$segment) %>%
-    left_join(df_network_segment, by="segment") %>%
+  result = network_segmented |>
+    filter(segment %in% df_network_segment$segment) |>
+    left_join(df_network_segment, by="segment") |>
     select(-segment)
 
   return(result)

--- a/man/network_overline.Rd
+++ b/man/network_overline.Rd
@@ -47,7 +47,7 @@ target_network = st_read("network_centerlines.gpkg")
 frequency_analysis <- GTFShift::get_route_frequency_hourly(gtfs, overline=FALSE)
 GTFShift::network_overline(
   target_network,
-  frequency_analysis \%>\% filter(arrival_hour==8),
+  frequency_analysis |> filter(arrival_hour==8),
   attr = "frequency"
 )
 }

--- a/man/network_overline.Rd
+++ b/man/network_overline.Rd
@@ -2,48 +2,52 @@
 % Please edit documentation in R/network_overline.R
 \name{network_overline}
 \alias{network_overline}
-\title{Aggregate lines based on overlap with simplified network}
+\title{Aggregate lines based on overlap with target network}
 \usage{
 network_overline(
-  network,
-  df,
+  target_network,
+  lines,
   attr,
-  network_segment_length = 100,
+  target_network_split = 100,
   fun = sum,
   join_dist = 10
 )
 }
 \arguments{
-\item{network}{sf. A spatial object representing the simplified network.}
+\item{target_network}{sf. A spatial object representing the target network.}
 
-\item{df}{sf. A spatial object representing the lines to aggregate.}
+\item{lines}{sf. A spatial object representing the lines to aggregate.}
 
 \item{attr}{String. The attribute to aggregate the lines by.}
 
-\item{network_segment_length}{Integer (Default 100). If not NA, network is split in segments of defined meters.}
+\item{target_network_split}{Integer (Default 100). If not NA, network is split in segments of defined meters.}
 
 \item{fun}{Method (Default \code{base::sum}). Function to summarise the attributes by.}
 
 \item{join_dist}{Integer (Default 10). Meters to consider when joining routes and network segments.}
 }
 \value{
-A spatial object of the network provided, extended with the aggregated values.
-A \code{segment} column will be also added to the network, as a unique identifier used for the aggregation process.
+A spatial object of the target network, extended with the aggregated values.
 }
 \description{
-Aggregate lines based on overlap with simplified network
+Aggregate lines based on overlap with target network
 }
 \details{
-This method allows for the lines aggregation. Given a simplified network, it identifies (using \code{stplanr::rnet_join()})
+This method allows for the lines aggregation. Given a target network, it identifies (using \code{stplanr::rnet_join()})
 the segments corresponding to each line and uses them to aggregate the attribute defined in the parameters.
+
+It provides an alternative to \code{GTFShift::get_route_frequency_hourly()} with the attribute \code{overline=TRUE}, which
+creates an aggregated network based on the lines overlap. Instead, \code{GTFShift::network_overline()} finds, for each network
+segment, the overlapping lines and aggregates their \code{attr} values, using \code{fun}.
 }
 \examples{
 \dontrun{
-network = st_read("network_centerlines.gpkg")
-frequency_analysis <- GTFShift::get_route_frequency_hourly(gtfs)
+gtfs <- GTFShift::load_feed("https://operator.com/gtfs.zip")
+target_network = st_read("network_centerlines.gpkg")
+frequency_analysis <- GTFShift::get_route_frequency_hourly(gtfs, overline=FALSE)
 GTFShift::network_overline(
-  network, f
-  requency_analysis \%>\% filter(arrival_hour==8),
+  target_network,
+  frequency_analysis \%>\% filter(arrival_hour==8),
   attr = "frequency"
 )
 }

--- a/vignettes/analyse.Rmd
+++ b/vignettes/analyse.Rmd
@@ -162,7 +162,7 @@ quantile(frequencies_route_overline_improved$frequency)
 mapview::mapview(
   frequencies_route_overline_improved |>
     select(frequency, segment) |>
-    filter(frequency > 6),
+    filter(frequency > 12),
   zcol = "frequency",
   # lwd = "frequency",
   layer.name = "Frequency (hour)"


### PR DESCRIPTION
Renamed attributes:
- `network` to `target_network`
- `df`to `lines`
- `network_segment_length` to `target_network_split`

Improved documentation, explaining different with `GTFShift::get_route_frequency_hourly` using `overline=TRUE`.
