### PR TITLE
34 methods docs improved after paper revision 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,0 @@
-# GTFShift 0.6.0
-
-# GTFShift 0.5.0
-

--- a/R/get_route_frequency_hourly.R
+++ b/R/get_route_frequency_hourly.R
@@ -4,11 +4,21 @@
 #'
 #' @param gtfs tidygtfs. GTFS feed.
 #' @param date Date (Default \code{GTFShift::calendar_nextBusinessWednesday()}). Reference date to consider when analyzing the GTFS file.
-#' @param use_osm_routes osmdata::opq (Default NA). If overpass query for transit network is defined, analysis is performed considering OSM route geometry, using \code{GTFShift::osm_shapes_to_routes}.
+#' @param use_osm_routes osmdata::opq (Default NA). If overpass query for transit network is defined, analysis is performed considering OSM route geometry, using \code{GTFShift::osm_shapes_to_routes()}.
 #' @param overline Boolean (Default FALSE). If TRUE, routes are aggregated using \code{stplanr::overline2()}, overlapping lines and converting them into a single route network.
 #'
 #' @details
 #' This method analyses the GTFS feed for a representative day, generating for each route the number of services aggregated per hour and direction.
+#' It assumes the time of departure at the first stop as a reference for each trip geometry.
+#'
+#' By default, it estimates the next business Wednesday, relevant for the peak hour.
+#'
+#' The \code{overline} parameter enables the aggregation of bus routes that share common line segments, returning a sum of frequencies per road segment, using \code{stplanr::overline2()}.
+#'
+#' Optionally, using \code{use_osm_routes} parameter, it retrieves the geometries from OpenStreetMap by matching the tag \code{gtfs:shape_id}, overwriting the original GTFS \code{shapes.txt}.
+#' This is particularly useful if the GTFS shapes do not share the same geometry. For instance, if the edges of the lines do not overlap or do not follow the same route-over-the-road – which is very common, even besides \href{https://gtfs.org/documentation/schedule/schedule-best-practices/#shapestxt}{GTFS recommendation} – geometries might not be aggregated correctly, causing inconsistent results.
+#' By relying on a common road network, such as OSM, it is possible to overcome this issue and aggregate the bus routes correctly.
+#'
 #' For a detailed example, see the \code{vignette("analyse")}.
 #'
 #' Adapted from \url{https://github.com/Bondify/GTFS_in_R/}.
@@ -29,7 +39,9 @@
 #' frequency_analysis = GTFShift::get_route_frequency_hourly(gtfs)
 #' }
 #'
-#' @seealso [tidytransit::read_gtfs()], [stplanr::overline2], [GTFShift::calendar_nextBusinessWednesday]
+#' @seealso \code{GTFShift::calendar_nextBusinessWednesday()}
+#' @seealso \code{GTFShift::osm_shapes_to_routes()}
+#' @seealso \code{stplanr::overline2()}
 #'
 #' @import tidytransit
 #' @import dplyr

--- a/R/get_stop_frequency_hourly.R
+++ b/R/get_stop_frequency_hourly.R
@@ -23,7 +23,7 @@
 #' frequency_analysis <- GTFShift::get_stop_frequency_hourly(gtfs)
 #' }
 #'
-#' @seealso [GTFShift::calendar_nextBusinessWednesday]
+#' @seealso \code{GTFShift::calendar_nextBusinessWednesday()}
 #'
 #' @import sf
 #' @import tidyverse

--- a/R/load_feed.R
+++ b/R/load_feed.R
@@ -20,9 +20,9 @@
 #'
 #' @returns A tidygtfs object.
 #'
-#' @seealso [tidytransit::read_gtfs()]
-#' @seealso [GTFSwizard::get_shapes()]
-#' @seealso [gtfsrouter::gtfs_transfer_table()]
+#' @seealso \code{tidytransit::read_gtfs()}
+#' @seealso \code{GTFSwizard::get_shapes()}
+#' @seealso \code{gtfsrouter::gtfs_transfer_table()}
 #'
 #' @examples
 #' \dontrun{

--- a/R/network_overline.R
+++ b/R/network_overline.R
@@ -30,7 +30,7 @@
 #' )
 #' }
 #'
-#' @seealso [stplanr::rnet_join]
+#' @seealso \code{stplanr::rnet_join()}
 #'
 #' @import stplanr
 #' @import sf

--- a/R/query_osm_shapes_to_routes.R
+++ b/R/query_osm_shapes_to_routes.R
@@ -14,6 +14,9 @@
 #'  \item \code{geometry}, the geometrical data for the OSM route relation.
 #' }
 #'
+#' Shapes that do not have a match on OSM are ignored.
+#' If that occurs, a warning is displayed during the method execution, informing about the missing geometries.
+#'
 #' @examples
 #' \dontrun{
 #' gtfs <- GTFShift::load_feed("gtfs.zip")

--- a/R/unify.R
+++ b/R/unify.R
@@ -28,8 +28,8 @@
 #' unified <- GTFShift::unify(gtfs1, gtfs2, create_transfers=TRUE)
 #' }
 #'
-#' @seealso [gtfstools::merge_gtfs()]
-#' @seealso [gtfsrouter::gtfs_transfer_table()]
+#' @seealso \code{gtfstools::merge_gtfs()}
+#' @seealso \code{gtfsrouter::gtfs_transfer_table()}
 #'
 #' @importFrom gtfstools merge_gtfs
 #' @importFrom gtfsrouter extract_gtfs gtfs_transfer_table

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GTFShift
 
 <!-- badges: start -->
-
+[![](https://github.com/U-Shift/GTFShift/actions/workflows/pkgdown.yaml/badge.svg)](https://github.com/U-Shift/GTFShift/actions/workflows/pkgdown.yaml)
 <!-- badges: end -->
 
 **GTFShift** emerged from the necessity to understand how to get an

--- a/man/get_route_frequency_hourly.Rd
+++ b/man/get_route_frequency_hourly.Rd
@@ -16,7 +16,7 @@ get_route_frequency_hourly(
 
 \item{date}{Date (Default \code{GTFShift::calendar_nextBusinessWednesday()}). Reference date to consider when analyzing the GTFS file.}
 
-\item{use_osm_routes}{osmdata::opq (Default NA). If overpass query for transit network is defined, analysis is performed considering OSM route geometry, using \code{GTFShift::osm_shapes_to_routes}.}
+\item{use_osm_routes}{osmdata::opq (Default NA). If overpass query for transit network is defined, analysis is performed considering OSM route geometry, using \code{GTFShift::osm_shapes_to_routes()}.}
 
 \item{overline}{Boolean (Default FALSE). If TRUE, routes are aggregated using \code{stplanr::overline2()}, overlapping lines and converting them into a single route network.}
 }
@@ -36,6 +36,16 @@ For each route, returns the number of departures aggregated per hour and directi
 }
 \details{
 This method analyses the GTFS feed for a representative day, generating for each route the number of services aggregated per hour and direction.
+It assumes the time of departure at the first stop as a reference for each trip geometry.
+
+By default, it estimates the next business Wednesday, relevant for the peak hour.
+
+The \code{overline} parameter enables the aggregation of bus routes that share common line segments, returning a sum of frequencies per road segment, using \code{stplanr::overline2()}.
+
+Optionally, using \code{use_osm_routes} parameter, it retrieves the geometries from OpenStreetMap by matching the tag \code{gtfs:shape_id}, overwriting the original GTFS \code{shapes.txt}.
+This is particularly useful if the GTFS shapes do not share the same geometry. For instance, if the edges of the lines do not overlap or do not follow the same route-over-the-road – which is very common, even besides \href{https://gtfs.org/documentation/schedule/schedule-best-practices/#shapestxt}{GTFS recommendation} – geometries might not be aggregated correctly, causing inconsistent results.
+By relying on a common road network, such as OSM, it is possible to overcome this issue and aggregate the bus routes correctly.
+
 For a detailed example, see the \code{vignette("analyse")}.
 
 Adapted from \url{https://github.com/Bondify/GTFS_in_R/}.
@@ -48,5 +58,9 @@ frequency_analysis = GTFShift::get_route_frequency_hourly(gtfs)
 
 }
 \seealso{
-[tidytransit::read_gtfs()], [stplanr::overline2], [GTFShift::calendar_nextBusinessWednesday]
+\code{GTFShift::calendar_nextBusinessWednesday()}
+
+\code{GTFShift::osm_shapes_to_routes()}
+
+\code{stplanr::overline2()}
 }

--- a/man/get_stop_frequency_hourly.Rd
+++ b/man/get_stop_frequency_hourly.Rd
@@ -38,5 +38,5 @@ frequency_analysis <- GTFShift::get_stop_frequency_hourly(gtfs)
 
 }
 \seealso{
-[GTFShift::calendar_nextBusinessWednesday]
+\code{GTFShift::calendar_nextBusinessWednesday()}
 }

--- a/man/load_feed.Rd
+++ b/man/load_feed.Rd
@@ -50,9 +50,9 @@ gtfs <- GTFShift::load_feed("https://operator.com/gtfs.zip")
 
 }
 \seealso{
-[tidytransit::read_gtfs()]
+\code{tidytransit::read_gtfs()}
 
-[GTFSwizard::get_shapes()]
+\code{GTFSwizard::get_shapes()}
 
-[gtfsrouter::gtfs_transfer_table()]
+\code{gtfsrouter::gtfs_transfer_table()}
 }

--- a/man/network_overline.Rd
+++ b/man/network_overline.Rd
@@ -54,5 +54,5 @@ GTFShift::network_overline(
 
 }
 \seealso{
-[stplanr::rnet_join]
+\code{stplanr::rnet_join()}
 }

--- a/man/osm_shapes_to_routes.Rd
+++ b/man/osm_shapes_to_routes.Rd
@@ -18,6 +18,9 @@ A \code{sf} \code{data.frame} with the following columns:
  \item \code{osm_id}, the \code{osm_id} attribute from OSM route relation.
  \item \code{geometry}, the geometrical data for the OSM route relation.
 }
+
+Shapes that do not have a match on OSM are ignored.
+If that occurs, a warning is displayed during the method execution, informing about the missing geometries.
 }
 \description{
 Get OSM routes geometry considering gtfs:shape_id match

--- a/man/unify.Rd
+++ b/man/unify.Rd
@@ -55,7 +55,7 @@ unified <- GTFShift::unify(gtfs1, gtfs2, create_transfers=TRUE)
 
 }
 \seealso{
-[gtfstools::merge_gtfs()]
+\code{gtfstools::merge_gtfs()}
 
-[gtfsrouter::gtfs_transfer_table()]
+\code{gtfsrouter::gtfs_transfer_table()}
 }


### PR DESCRIPTION
> Make adjustments following paper revision:
> 
> - [x] `get_route_frequency_hourly()`, disclose that we assume first stop as hour for each trip geometry
> - [x] `get_route_frequency_hourly()`, refer osm method more properly
> - [x] improve osm match routes method, to disclose that routes not matched are ignored
> - [x] add feedback to osm match routes method
> - [x] Add CI/CD badge to repo 

 _Originally posted by @gmatosferreira in [#34](https://github.com/U-Shift/GTFShift/issues/34#issuecomment-3167455126)_