### PR TITLE
#43 get_stop_frequency_hourly method improved to return frequencies f…

### DIFF
--- a/R/get_stop_frequency_hourly.R
+++ b/R/get_stop_frequency_hourly.R
@@ -102,7 +102,7 @@ get_stop_frequency_hourly <- function(gtfs, date = GTFShift::calendar_nextBusine
 
   frame = data.frame()
 
-  stop_times = gtfs$stop_times |>mutate(hour = lubridate::hour(departure_time))
+  stop_times = gtfs_date$stop_times |> mutate(hour = lubridate::hour(departure_time))
   min_hour = min(stop_times$hour, na.rm=TRUE)
   max_hour = max(stop_times$hour, na.rm=TRUE)
 


### PR DESCRIPTION
get_stop_frequency_hourly method improved to return frequencies for all the hours for which there are stop_times, instead of fixed interval between 6 and 23